### PR TITLE
Fixed MQTT ClientID formatting for Mosquitto with Auth Plugin compatibility

### DIFF
--- a/client.go
+++ b/client.go
@@ -118,7 +118,7 @@ func (c *Client) pubMessages(in, out chan *Message, doneGen, donePub chan bool) 
 
 	opts := mqtt.NewClientOptions().
 		AddBroker(c.BrokerURL).
-		SetClientID(fmt.Sprintf("mqtt-benchmark-%v-%v", time.Now(), c.ID)).
+		SetClientID(fmt.Sprintf("mqtt-benchmark-%v-%v", time.Now().Format(time.RFC3339Nano), c.ID)).
 		SetCleanSession(true).
 		SetAutoReconnect(true).
 		SetOnConnectHandler(onConnected).


### PR DESCRIPTION
Without this patch, mosquitto denies the connection citing that the client id is "dangerous".

Here is an example log from mosquitto with the auth plugin installed:
```
ACL denying access to client with dangerous client id "mqtt-benchmark-2018-06-12 18:20:53.774264728 -0400 EDT m=+0.002009127-10"
```