### PR TITLE
Publish on multiple topics

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ import (
 	"time"
 	"math/rand"
 	"strings"
-    "strconv"
+    	"strconv"
 )
 
 import (
@@ -75,7 +75,7 @@ func (c *Client) genMessages(ch chan *Message, done chan bool) {
 	for i := 0; i < c.MsgCount; i++ {
 		var topic = c.MsgTopic
 		if c.nTopics > 1 {
-				topic = strings.Join([]string{c.MsgTopic, strconv.Itoa(rand.Intn(c.nTopics))}, "")
+				topic = strings.Join([]string{c.MsgTopic+"/", strconv.Itoa(rand.Intn(c.nTopics))}, "")
 			}
 		ch <- &Message{
 			Topic:   topic,

--- a/client.go
+++ b/client.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"math/rand"
+	"strings"
+    "strconv"
 )
 
 import (
@@ -21,6 +24,8 @@ type Client struct {
 	MsgCount   int
 	MsgQoS     byte
 	Quiet      bool
+	nTopics    int
+
 }
 
 func (c *Client) Run(res chan *RunResults) {
@@ -68,8 +73,12 @@ func (c *Client) Run(res chan *RunResults) {
 
 func (c *Client) genMessages(ch chan *Message, done chan bool) {
 	for i := 0; i < c.MsgCount; i++ {
+		var topic = c.MsgTopic
+		if c.nTopics > 1 {
+				topic = strings.Join([]string{c.MsgTopic, strconv.Itoa(rand.Intn(c.nTopics))}, "")
+			}
 		ch <- &Message{
-			Topic:   c.MsgTopic,
+			Topic:   topic,
 			QoS:     c.MsgQoS,
 			Payload: make([]byte, c.MsgSize),
 		}

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 		clients  = flag.Int("clients", 10, "Number of clients to start")
 		format   = flag.String("format", "text", "Output format: text|json")
 		quiet    = flag.Bool("quiet", false, "Suppress logs while running")
+		numTopics = flag.Int("numTopics", 1, "Number of different topics")
 	)
 
 	flag.Parse()
@@ -91,6 +92,8 @@ func main() {
 			MsgCount:   *count,
 			MsgQoS:     byte(*qos),
 			Quiet:      *quiet,
+			nTopics: 	*numTopics,
+
 		}
 		go c.Run(resCh)
 	}


### PR DESCRIPTION
Since analyse how the broker reacts on several publish also on different topics could be interesting, I added the following feature:

- numTopics

With _numTopics_ the number of different topics can be chosen launching mqtt-benchmark. The client will randomly publish on a topic. 
The code adds a random number to the current topic, creating a second level (e.g. "/topic/39").
