### PR TITLE
Adds client prefix for generating predictable client ID's

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The tool supports multiple concurrent clients, configurable message size, etc:
 Usage of mqtt-benchmark:
   -broker="tcp://localhost:1883": MQTT broker endpoint as scheme://host:port
   -cert="cert.pem": File path to your client certificate in PEM format
+  -client-id="mqtt-benchmark": MQTT client id
   -clients=10: Number of clients to start
   -count=100: Number of messages to send per client
   -format="text": Output format: text|json

--- a/client.go
+++ b/client.go
@@ -5,15 +5,14 @@ import (
 	"fmt"
 	"log"
 	"time"
-)
 
-import (
 	"github.com/GaryBoone/GoStats/stats"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 type Client struct {
 	ID          int
+	ClientID    string
 	BrokerURL   string
 	BrokerUser  string
 	BrokerPass  string
@@ -127,7 +126,7 @@ func (c *Client) pubMessages(in, out chan *Message, doneGen, donePub chan bool) 
 
 	opts := mqtt.NewClientOptions().
 		AddBroker(c.BrokerURL).
-		SetClientID(fmt.Sprintf("mqtt-benchmark-%v-%v", time.Now().Format(time.RFC3339Nano), c.ID)).
+		SetClientID(fmt.Sprintf("%s-%v", c.ClientID, c.ID)).
 		SetCleanSession(true).
 		SetAutoReconnect(true).
 		SetOnConnectHandler(onConnected).

--- a/main.go
+++ b/main.go
@@ -57,10 +57,10 @@ type JSONResults struct {
 }
 
 func main() {
-
 	var (
 		broker   = flag.String("broker", "tcp://localhost:1883", "MQTT broker endpoint as scheme://host:port")
 		topic    = flag.String("topic", "/test", "MQTT topic for outgoing messages")
+		clientID = flag.String("client-id", "mqtt-benchmark", "MQTT client id")
 		username = flag.String("username", "", "MQTT username (empty if auth disabled)")
 		password = flag.String("password", "", "MQTT password (empty if auth disabled)")
 		qos      = flag.Int("qos", 1, "QoS for published messages")
@@ -104,6 +104,7 @@ func main() {
 		}
 		c := &Client{
 			ID:          i,
+			ClientID:    *clientID,
 			BrokerURL:   *broker,
 			BrokerUser:  *username,
 			BrokerPass:  *password,


### PR DESCRIPTION
This change adds command line argument `prefix`, so we can generate predictable client ID's.