### PR TITLE
Adds QoS 1 PUBACK wait timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Usage of mqtt-benchmark:
   -size=100: Size of the messages payload (bytes)
   -topic="/test": MQTT topic for incoming message
   -username="": MQTT username (empty if auth disabled)
+  -wait="60000": QoS 1 wait timeout in milliseconds (default 60000)
 ```
 
 > NOTE: if `count=1` or `clients=1`, the sample standard deviation will be returned as `0` (convention due to the [lack of NaN support in JSON](https://tools.ietf.org/html/rfc4627#section-2.4))

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 		username = flag.String("username", "", "MQTT username (empty if auth disabled)")
 		password = flag.String("password", "", "MQTT password (empty if auth disabled)")
 		qos      = flag.Int("qos", 1, "QoS for published messages")
+		wait     = flag.Int("wait", 60000, "QoS 1 wait timeout in milliseconds")
 		size     = flag.Int("size", 100, "Size of the messages payload (bytes)")
 		count    = flag.Int("count", 100, "Number of messages to send per client")
 		clients  = flag.Int("clients", 10, "Number of clients to start")
@@ -86,15 +87,16 @@ func main() {
 			log.Println("Starting client ", i)
 		}
 		c := &Client{
-			ID:         i,
-			BrokerURL:  *broker,
-			BrokerUser: *username,
-			BrokerPass: *password,
-			MsgTopic:   *topic,
-			MsgSize:    *size,
-			MsgCount:   *count,
-			MsgQoS:     byte(*qos),
-			Quiet:      *quiet,
+			ID:          i,
+			BrokerURL:   *broker,
+			BrokerUser:  *username,
+			BrokerPass:  *password,
+			MsgTopic:    *topic,
+			MsgSize:     *size,
+			MsgCount:    *count,
+			MsgQoS:      byte(*qos),
+			Quiet:       *quiet,
+			WaitTimeout: time.Duration(*wait) * time.Millisecond,
 		}
 		go c.Run(resCh)
 	}


### PR DESCRIPTION
Change introduces WaitTimeout on message publish.
Client will only wait limited amount of time on PUBACK package.

Change was implemented because some IoT platforms for example AWS IoT Core rate limit QoS 1 messages. When rate limit is reached message is dropped, so client will never get `PUBACK` package and this results in benchmark tool to hang for ever.

In real time scenario, after wait timeout occurrences client would retry sending package, but for `mqtt-benchmark` tool this is actually not needed.

Use case would be WaitTimeout is set to few seconds for example 5. But `mqtt-benchmark` default value is 60 sec, so default behavior is similar to not having timeout.
